### PR TITLE
Change to using ipify.org to get external IP address

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>BNDL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.4.0</string>
+	<string>1.4.1</string>
 	<key>CFBundleVersion</key>
-	<string>E</string>
+	<string>F</string>
 	<key>QSActions</key>
 	<dict>
 		<key>QSAirPortDisassociate</key>
@@ -159,7 +159,7 @@
 	<key>QSDefaults</key>
 	<dict>
 		<key>QSExternalIPSource</key>
-		<string>http://plain-text-ip.com/</string>
+		<string>https://api.ipify.org</string>
 	</dict>
 	<key>QSPlugIn</key>
 	<dict>
@@ -176,8 +176,8 @@
 &lt;h3&gt;Catalog&lt;/h3&gt;
 &lt;h4&gt;Presets&lt;/h4&gt;
 &lt;ul&gt;
-&lt;li&gt;Network Locations - Adds any netowrk locations you've configured in System Preferences to the catalog. (Disabled by default)&lt;/li&gt;
-&lt;li&gt;Wireless Interface - A virtual entry that represents your Wi-Fi connection. Use this to turn the interface on and off, or to view available networks by hitting → or /. (For 10.6 users, this will appear in the catalog under the name "AirPort".)&lt;/li&gt;
+&lt;li&gt;Network Locations - Adds any netowrk locations you&apos;ve configured in System Preferences to the catalog. (Disabled by default)&lt;/li&gt;
+&lt;li&gt;Wireless Interface - A virtual entry that represents your Wi-Fi connection. Use this to turn the interface on and off, or to view available networks by hitting → or /. (For 10.6 users, this will appear in the catalog under the name &quot;AirPort&quot;.)&lt;/li&gt;
 &lt;/ul&gt;
 &lt;h4&gt;Proxy Objects&lt;/h4&gt;
 &lt;ul&gt;
@@ -187,12 +187,12 @@
 &lt;h3&gt;Actions&lt;/h3&gt;
 &lt;ul&gt;
 &lt;li&gt;Switch to Location - when a network location is selected in the first pane, this will allow you to set it as the active location.&lt;/li&gt;
-&lt;li&gt;Turn Wi-Fi On - Enable power for the wireless interface. This action is only available when power is off. (The action is named "Turn AirPort On" for 10.6 users.)&lt;/li&gt;
-&lt;li&gt;Turn Wi-Fi Off - Disable power for the wireless interface. This action is only available when power is on. (The action is named "Turn AirPort Off" for 10.6 users.)&lt;/li&gt;
-&lt;li&gt;Toggle Wi-Fi Power - Toggle power for the wireless interface. Useful for creating triggers. (The action is named "Toggle AirPort Off" for 10.6 users.)&lt;/li&gt;
+&lt;li&gt;Turn Wi-Fi On - Enable power for the wireless interface. This action is only available when power is off. (The action is named &quot;Turn AirPort On&quot; for 10.6 users.)&lt;/li&gt;
+&lt;li&gt;Turn Wi-Fi Off - Disable power for the wireless interface. This action is only available when power is on. (The action is named &quot;Turn AirPort Off&quot; for 10.6 users.)&lt;/li&gt;
+&lt;li&gt;Toggle Wi-Fi Power - Toggle power for the wireless interface. Useful for creating triggers. (The action is named &quot;Toggle AirPort Off&quot; for 10.6 users.)&lt;/li&gt;
 &lt;li&gt;Disconnect Current Network - Disassociate from the current wireless network, but keep power for the interface on.&lt;/li&gt;
 &lt;li&gt;Connect to Network - Connect to the selected wireless network. This is only available for unsecured networks and secured networks for which you have credentials stored in your keychain.&lt;/li&gt;
-&lt;li&gt;Connect to Network (via Menubar) - For secured networks that can't be automatically joined, this action will attempt to click through the menu bar to select the network for you, which should result in you being prompted for credentials.&lt;/li&gt;
+&lt;li&gt;Connect to Network (via Menubar) - For secured networks that can&apos;t be automatically joined, this action will attempt to click through the menu bar to select the network for you, which should result in you being prompted for credentials.&lt;/li&gt;
 &lt;/ul&gt;</string>
 		<key>icon</key>
 		<string>GenericNetworkIcon</string>

--- a/Networking/NetworkingSource.m
+++ b/Networking/NetworkingSource.m
@@ -60,6 +60,7 @@
 		[localIP setName:@"IP Address"];
 		[localIP setDetails:[addresses componentsJoinedByString:@", "]];
 		[localIP setObject:[addresses componentsJoinedByString:@" "] forType:QSTextType];
+		[localIP setIcon:[QSResourceManager imageNamed:@"GenericNetworkIcon"]];
 		return localIP;
 	}
 	// remote IP address
@@ -85,6 +86,7 @@
 			[externalIP setName:@"External IP Address"];
 			[externalIP setDetails:content];
 			[externalIP setObject:content forType:QSTextType];
+			[externalIP setIcon:[QSResourceManager imageNamed:@"GenericNetworkIcon"]];
 			return externalIP;
 		}
 	}

--- a/Networking/NetworkingSource.m
+++ b/Networking/NetworkingSource.m
@@ -68,8 +68,13 @@
 		NSURL *IPService = [NSURL URLWithString:externalIPSource];
 		NSURLRequest *req = [NSURLRequest requestWithURL:IPService cachePolicy:NSURLRequestReloadIgnoringLocalCacheData timeoutInterval:5];
 		NSURLResponse *response;
-		NSError *error;
+		NSError *error = nil;
 		NSData *contentData = [NSURLConnection sendSynchronousRequest:req returningResponse:&response error:&error];
+		if (error) {
+			NSLog(@"Error retrieving external IP address: %@", error);
+			NSBeep();
+			return nil;
+		}
 		NSString *content = [[[NSString alloc] initWithData:contentData encoding:NSUTF8StringEncoding] autorelease];
 		content = [content stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
 		NSRegularExpression *ipRegEx = [NSRegularExpression regularExpressionWithPattern:@"^\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}$" options:0 error:nil];


### PR DESCRIPTION
I've been getting 500 server errors for a couple of days from: http://plain-text-ip.com/

This commit changes to using ipify.org to get the external IP.

@skurfer  - you know the most about this plugin so I'll let you make the final decision.